### PR TITLE
Patch for Windows 10 Anniversary Update

### DIFF
--- a/WPFTabTip/TabTipAutomation.cs
+++ b/WPFTabTip/TabTipAutomation.cs
@@ -25,6 +25,24 @@ namespace WPFTabTip
 
         private static readonly List<Type> BindedUIElements = new List<Type>();
 
+        public enum DockModeOptions
+        {
+            /// <summary>
+            /// Dock the keyboard to the taskbar.
+            /// </summary>
+            Docked,
+
+            /// <summary>
+            /// Undock the keyboard (floating window).
+            /// </summary>
+            Undocked,
+
+            /// <summary>
+            /// Do not change the docking behaviour.
+            /// </summary>
+            NoChange
+        }
+
         /// <summary>
         /// By default TabTip automation happens only when no keyboard is connected to device.
         /// Change IgnoreHardwareKeyboard if you want to automate
@@ -35,6 +53,8 @@ namespace WPFTabTip
             get { return HardwareKeyboard.IgnoreOptions; }
             set { HardwareKeyboard.IgnoreOptions = value; } 
         }
+
+        public static DockModeOptions DockingMode { get; set; } = DockModeOptions.Undocked;
 
         /// <summary>
         /// Description of keyboards to ignore if there is only one instance of given keyboard.
@@ -63,7 +83,7 @@ namespace WPFTabTip
                 .ObserveOn(Scheduler.Default)
                 .Where(_ => IgnoreHardwareKeyboard == HardwareKeyboardIgnoreOptions.IgnoreAll || !HardwareKeyboard.IsConnectedAsync().Result)
                 .Where(tuple => tuple.Item2 == true)
-                .Do(_ => TabTip.OpenUndockedAndStartPoolingForClosedEvent())
+                .Do(_ => TabTip.OpenAndStartPoolingForClosedEvent(DockingMode))
                 .ObserveOnDispatcher()
                 .Subscribe(tuple => AnimationHelper.GetUIElementInToWorkAreaWithTabTipOpened(tuple.Item1));
         }

--- a/WPFTabTip/TrayIcon.cs
+++ b/WPFTabTip/TrayIcon.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPFTabTip
+{
+    internal static class TrayIcon
+    {
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr FindWindow(string sClassName, string sAppName);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string lclassName, string windowTitle);
+
+        [DllImport("User32.Dll", EntryPoint = "PostMessageA")]
+        private static extern bool PostMessage(IntPtr hWnd, uint msg, int wParam, int lParam);
+
+        public static void Trigger()
+        {
+            var nullIntPtr = IntPtr.Zero;
+            var trayWnd = FindWindow("Shell_TrayWnd", null);
+
+            if (trayWnd != nullIntPtr)
+            {
+                var trayNotifyWnd = FindWindowEx(trayWnd, nullIntPtr, "TrayNotifyWnd", null);
+                if (trayNotifyWnd != nullIntPtr)
+                {
+                    var tIPBandWnd = FindWindowEx(trayNotifyWnd, nullIntPtr, "TIPBand", null);
+
+                    if (tIPBandWnd != nullIntPtr)
+                    {
+                        PostMessage(tIPBandWnd, (UInt32)WMessages.WM_LBUTTONDOWN, 1, 65537);
+                        PostMessage(tIPBandWnd, (UInt32)WMessages.WM_LBUTTONUP, 1, 65537);
+                    }
+                }
+            }
+        }
+
+        public enum WMessages : int
+        {
+            WM_LBUTTONDOWN = 0x201,
+            WM_LBUTTONUP = 0x202,
+            WM_KEYDOWN = 0x100,
+            WM_KEYUP = 0x101,
+            WH_KEYBOARD_LL = 13,
+            WH_MOUSE_LL = 14,
+        }
+    }
+}

--- a/WPFTabTip/WPFTabTip.csproj
+++ b/WPFTabTip/WPFTabTip.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TabTipAutomation.cs" />
     <Compile Include="Taskbar.cs" />
+    <Compile Include="TrayIcon.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
- fixes #2 
- includes a new option "DockMode"
- automatically triggers the keyboard tray icon
- small refactoring of Open vs OpenUndocked
