### PR TITLE
Small fix and one new option

### DIFF
--- a/WPFTabTip/AnimationHelper.cs
+++ b/WPFTabTip/AnimationHelper.cs
@@ -296,14 +296,13 @@ namespace WPFTabTip
             foreach (KeyValuePair<FrameworkElement, Storyboard> moveRootVisualStoryboard in MoveRootVisualStoryboards)
             {
                 Window window = moveRootVisualStoryboard.Key as Window;
-                if (window != null)
-                    MoveRootVisualBy(
-                    rootVisual: window,
-                    moveBy: GetYOffsetToMoveUIElementInToWorkArea(
-                        uiElementRectangle: GetWindowRectangle(window),
-                        workAreaRectangle: GetWorkAreaWithTabTipClosed(window)));
+                // if window exist also check if it has not been closed
+                if (window != null && new WindowInteropHelper(window).Handle != IntPtr.Zero)
+                {
+                    MoveRootVisualBy(window, GetYOffsetToMoveUIElementInToWorkArea(GetWindowRectangle(window), GetWorkAreaWithTabTipClosed(window)));
+                }
                 else
-                    MoveRootVisualTo(rootVisual: moveRootVisualStoryboard.Key, moveTo: 0);
+                    MoveRootVisualTo(moveRootVisualStoryboard.Key, 0);
             }
         } 
 

--- a/WPFTabTip/HardwareKeyboard.cs
+++ b/WPFTabTip/HardwareKeyboard.cs
@@ -29,6 +29,12 @@ namespace WPFTabTip
         IgnoreAll
     }
 
+    public enum PopupOptions
+    {
+        NoPopupOnTap,
+        PopupOnTap = 1    
+    }
+
     internal static class HardwareKeyboard
     {
         private static bool? _isConnected;

--- a/WPFTabTip/Screen.cs
+++ b/WPFTabTip/Screen.cs
@@ -13,13 +13,21 @@ namespace WPFTabTip
 
         public Screen(Window window)
         {
-            IntPtr windowHandle = new WindowInteropHelper(window).EnsureHandle();
+            // Previously this function would often close if focus was lost when popping up a messagebox then closing form
+            
+            // Use Handle instead of EnsureHandle as latter will crash if window has been closed 
+            // Should not get here if that is the case due to check in GetEverythingInToWorkAreaWithTabTipClosed(), 
+            // but I feel EnsureHandle should not be used here regardless and it is a safeguard
+
+            IntPtr windowHandle = new WindowInteropHelper(window).Handle;
+            
             IntPtr monitor = NativeMethods.MonitorFromWindow(windowHandle, NativeMethods.MONITOR_DEFAULTTONEAREST);
 
             NativeMethods.NativeMonitorInfo monitorInfo = new NativeMethods.NativeMonitorInfo();
             NativeMethods.GetMonitorInfo(monitor, monitorInfo);
 
             Bounds = Rectangle.FromLTRB(monitorInfo.Monitor.Left, monitorInfo.Monitor.Top, monitorInfo.Monitor.Right, monitorInfo.Monitor.Bottom);
+
         }
 
         private static class NativeMethods


### PR DESCRIPTION
- Fixed crash that would occur if FocusLost was handled after window was closed. Typically happens if you show a MessageBox before closing your form.

- Added option for activating on Tap, not only on GotFocus. Useful for popping up soft-keyboard after you have closed it and editbox still has focus.

Signed-off-by: Njål Eide <njal.eide@evry.com>