### PR TITLE
Fixed Keyboard not showing second time.

### DIFF
--- a/WPFTabTip/TabTipAutomation.cs
+++ b/WPFTabTip/TabTipAutomation.cs
@@ -106,6 +106,16 @@ namespace WPFTabTip
                 handledEventsToo: true);
 
             EventManager.RegisterClassHandler(
+                classType: typeof(T),
+                routedEvent: UIElement.PreviewMouseDownEvent,
+                handler: new RoutedEventHandler((s, e) =>
+                {
+                    if (((UIElement)s).IsFocused)
+                        FocusSubject.OnNext(new Tuple<UIElement, bool>((UIElement)s, true));
+                }),
+                handledEventsToo: true);
+
+            EventManager.RegisterClassHandler(
                 classType: typeof(T), 
                 routedEvent: UIElement.GotFocusEvent, 
                 handler: new RoutedEventHandler((s, e) => FocusSubject.OnNext(new Tuple<UIElement, bool>((UIElement) s, true))), 


### PR DESCRIPTION
I had this issue in a project I am working with. The issue is essentially the fact that the bind occurs only in two cases: Focus (which is the first time the textblock is clicked), and touchdown. However, if the textbox does not loose focus, and one clicks on the textbox with the mouse, instead of using the touch screen, the keyboard will not popup.

This pull request fixes this issue by also binding the PreviewMouseDown event.
According to MSDN, we should not override MouseDown, as textboxes have their own behavior for that.

This fix referes Issue [20](https://github.com/maximcus/WPFTabTip/issues/20)